### PR TITLE
fixed issue #2 (Same user profile returned)

### DIFF
--- a/bangazon_api/views/profile_view.py
+++ b/bangazon_api/views/profile_view.py
@@ -28,7 +28,7 @@ class ProfileView(ViewSet):
     def my_profile(self, request):
         """Get the current user's profile"""
         try:
-            serializer = UserSerializer(User.objects.first())
+            serializer = UserSerializer(User.objects.filter(pk = request.user.id).get())
             return Response(serializer.data)
         except User.DoesNotExist as ex:
             return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
# Description

Fixes #2 

changed the method used in the `my_profile` custom action from .first() to .filter()

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

in swagger login as a registered user
scroll down to profile section and run a get on the /profile​/my-profile
it should return your info
logout and log back in as a different user and repeat step 2
it should now be that new users info


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
