### PR TITLE
fixed issue# 3(incorrect minimum products being returned)

### DIFF
--- a/bangazon_api/views/product_view.py
+++ b/bangazon_api/views/product_view.py
@@ -12,6 +12,7 @@ from bangazon_api.models import Product, Store, Category, Order, Rating, Recomme
 from bangazon_api.serializers import (
     ProductSerializer, CreateProductSerializer, MessageSerializer,
     AddProductRatingSerializer, AddRemoveRecommendationSerializer)
+from django.db.models import Q
 
 
 class ProductView(ViewSet):
@@ -169,8 +170,10 @@ class ProductView(ViewSet):
 
         if number_sold:
             products = products.annotate(
-                order_count=Count('orders')
-            ).filter(order_count__lt=number_sold)
+                order_count=Count('orders', filter=~Q(orders__payment_type=None))
+                # the __ between orders and payment is saying form orders, look at payment type
+                # the =~ is the same as !=
+            ).filter(order_count__gte=number_sold)
 
         if order is not None:
             order_filter = f'-{order}' if direction == 'desc' else order

--- a/db.sql
+++ b/db.sql
@@ -1,0 +1,3 @@
+SELECT *
+FROM bangazon_api_orderproduct
+ORDER BY product_id ASC


### PR DESCRIPTION
# Description

The user can now request a list of products that have been sold >= a number they choose

Fixes #3 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

in swagger, scroll down to the Products section and open the GET /products tab
in the number sold field, enter any number and hit execute
the response will a list of products where the value of the number_purchased field is >= the number you entered in the field above

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
