### PR TITLE
fixed issue7 (get list of products by min price)

### DIFF
--- a/bangazon_api/views/product_view.py
+++ b/bangazon_api/views/product_view.py
@@ -167,6 +167,7 @@ class ProductView(ViewSet):
         order = request.query_params.get('order_by', None)
         direction = request.query_params.get('direction', None)
         name = request.query_params.get('name', None)
+        min_price = request.query_params.get('min_price', None)
 
         if number_sold:
             products = products.annotate(
@@ -174,6 +175,9 @@ class ProductView(ViewSet):
                 # the __ between orders and payment is saying form orders, look at payment type
                 # the =~ is the same as !=
             ).filter(order_count__gte=number_sold)
+            
+        if min_price:
+            products = products.filter(price__gte=min_price)
 
         if order is not None:
             order_filter = f'-{order}' if direction == 'desc' else order


### PR DESCRIPTION
# Description

added code to allow user to get a list of products by a minimum price specified in the URL.

Fixes #7

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

in swagger scroll down to products section
open the GET /products tab
scroll down to the min_price field and enter a number
click execute and a list of products that are >= the price you entered should be returned

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

- [x] My changes generate no new warnings
