### PR TITLE
issue 6 fixed (only the users payments types are returned

### DIFF
--- a/bangazon_api/views/payment_type_view.py
+++ b/bangazon_api/views/payment_type_view.py
@@ -7,6 +7,8 @@ from drf_yasg import openapi
 from bangazon_api.models import PaymentType
 from bangazon_api.serializers import (
     PaymentTypeSerializer, MessageSerializer, CreatePaymentType)
+from django.contrib.auth.models import User
+
 
 
 class PaymentTypeView(ViewSet):
@@ -18,9 +20,15 @@ class PaymentTypeView(ViewSet):
     })
     def list(self, request):
         """Get a list of payment types for the current user"""
-        payment_types = PaymentType.objects.all()
-        serializer = PaymentTypeSerializer(payment_types, many=True)
-        return Response(serializer.data)
+        try:
+            payment_types = PaymentType.objects.all()
+
+            payment_type = payment_types.filter(customer = request.auth.user)
+            serializer = PaymentTypeSerializer(payment_type, many=True)
+            return Response(serializer.data)
+        except PaymentType.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+       
 
     @swagger_auto_schema(
         request_body=CreatePaymentType,


### PR DESCRIPTION
# Description

only logged in users payment types will display now

Fixes #6 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

In swagger, scroll down to payment types and run a get. Only the payment types made by that user will display.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

- [x] My changes generate no new warnings
