### PR TITLE
issue9 can add new prodcuts with a zero rating

### DIFF
--- a/bangazon_api/models/product.py
+++ b/bangazon_api/models/product.py
@@ -27,12 +27,17 @@ class Product(models.Model):
             number -- The average rating for the product
         """
         # TODO: Fix Divide by zero error
-
+        
         total_rating = 0
         for rating in self.ratings.all():
             total_rating += rating.score
 
-        avg = total_rating / self.ratings.count()
+        if total_rating > 0:
+            avg = total_rating / self.ratings.count()
+            return avg
+        elif total_rating == 0:
+            avg = 0
+            return avg
         return avg
 
     @property


### PR DESCRIPTION
# Description

Fixes #9 

you can now add a new product from swagger, and there is no divide by zero error.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

In swagger login as a registered user
make sure you have a store created for this user
scroll to the products section and open the POST /product tab
fill out the field and click execute
the new product object should display and on the front end should now display on the DOM.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
