### PR TITLE
incomplete orders report

### DIFF
--- a/bangazon_reports/templates/orders/incompleted_orders.html
+++ b/bangazon_reports/templates/orders/incompleted_orders.html
@@ -1,0 +1,20 @@
+{% load static %}
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Bangazon Reports</title>
+  </head>
+  <body>
+    <h1>Incomplete Orders</h1>
+    {% comment %} incompleted_orders is the key from the context we defined in the incomplleted orders view {% endcomment %}
+    {% for order in incompleted_orders %}
+        <h2>Order #{{ order.order_id }}</h2>
+        <ul>
+            <li>Customer Name: {{order.name}}</li>
+            <li>Date created: {{order.created_on}}
+            <li>Total to be paid: ${{order.total}}</li>
+        </ul>
+    {% endfor %}
+  </body>
+</html>

--- a/bangazon_reports/urls.py
+++ b/bangazon_reports/urls.py
@@ -1,8 +1,11 @@
 from django.urls import path
-from .views import ProductList, InexpensiveProductList, CompletedOrdersList
+from .views import ProductList, InexpensiveProductList, CompletedOrdersList, IncompletedOrdersList
 
 urlpatterns = [
+    # this defines the URL we'll use to to see the report and the views needed to get the relevant data
     path('reports/expensiveproducts', ProductList.as_view()),
     path('reports/inexpensiveproducts', InexpensiveProductList.as_view()),
     path('orders/completedorders', CompletedOrdersList.as_view()),
+    path('orders/incompletedorders', IncompletedOrdersList.as_view()),
+
 ]

--- a/bangazon_reports/views/__init__.py
+++ b/bangazon_reports/views/__init__.py
@@ -1,3 +1,4 @@
 from .products.productsbyprice import ProductList
 from .products.inexpensiveproducts import InexpensiveProductList
 from .orders.completedorders import CompletedOrdersList
+from .orders.incompletedorders import IncompletedOrdersList

--- a/bangazon_reports/views/orders/incompletedorders.py
+++ b/bangazon_reports/views/orders/incompletedorders.py
@@ -1,0 +1,57 @@
+from django.shortcuts import render
+from django.db import connection
+from django.views import View
+
+from bangazon_reports.views.helpers import dict_fetch_all
+
+# This class will need to be imported in the views/__init__.py
+class IncompletedOrdersList(View):
+    def get(self, request):
+        with connection.cursor() as db_cursor:
+            # This is the SQL statement that will get the relevant data for report
+            db_cursor.execute("""
+            SELECT o.id as order_id, u.first_name || " " || u.last_name as full_name, sum(price) as total_price, pt.merchant_name as payment_type, o.created_on as created_on
+            FROM bangazon_api_order o
+            JOIN auth_user u
+            ON o.user_id = u.id
+            LEFT JOIN bangazon_api_paymenttype pt 
+            ON pt.id = o.payment_type_id
+            JOIN bangazon_api_orderproduct op 
+            ON op.order_id = o.id
+            JOIN bangazon_api_product p 
+            ON p.id = op.product_id
+            WHERE payment_type is NULL
+            GROUP BY order_id
+            ORDER BY o.created_on ASC
+            """)
+            
+            # This turns the fetch_all response into a dictionary
+            dataset = dict_fetch_all(db_cursor)
+            
+            # This will be the list that holds the the data we get from the dataset
+            incompleted_orders = []
+            
+            # This takes the dictionaries coming from dataset, and tells it what rows
+            for row in dataset:
+                # The keys defined here is what we'll use on the html side when interpolating
+                # The values for each key are coming from the sql statement above (ex. SUM(price) as total_price)
+                order = {
+                    "order_id": row['order_id'],
+                    "name": row['full_name'],
+                    "total": row['total_price'],
+                    "created_on": row['created_on']
+                }
+                # pushes the order to the incompleted_orders list
+                incompleted_orders.append(order)
+        
+        #this is what file path we're using for the html 
+        template = 'orders/incompleted_orders.html'
+        
+        # The context will be a dictionary that the template can access to show data
+        # the key is what we'll use in the .html to iterate through for the data
+        # the value, in this case is the incompleted_orders list from above
+        context = {
+            "incompleted_orders": incompleted_orders
+        }
+
+        return render(request, template, context)           

--- a/db.sql
+++ b/db.sql
@@ -11,14 +11,19 @@ ON op.product_id = p.id
 GROUP BY o.id
 
 
-SELECT o.id order_id, u.first_name, u.last_name, pt.merchant_name payment_type, op.*, SUM(p.price) total_price
+SELECT o.id as order_id, u.first_name || " " || u.last_name as full_name, sum(price) as total_paid, pt.merchant_name as payment_type, o.created_on
 FROM bangazon_api_order o
 JOIN auth_user u
 ON o.user_id = u.id
-JOIN bangazon_api_paymenttype pt 
-ON o.payment_type_id = pt.id
+LEFT JOIN bangazon_api_paymenttype pt 
+ON pt.id = o.payment_type_id
 JOIN bangazon_api_orderproduct op 
-ON o.id = op.order_id
+ON op.order_id = o.id
 JOIN bangazon_api_product p 
-ON op.product_id = p.id
-GROUP BY o.id
+ON p.id = op.product_id
+WHERE payment_type is NULL
+GROUP BY order_id
+ORDER BY o.created_on ASC
+
+
+


### PR DESCRIPTION
# Description

added the code to retireve a report displaying all inccomplete orders

Fixes #21 

## Type of change

Please delete options that are not relevant.


- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

enter http://localhost:8000/orders/incompletedorders in your url and a report showing all orders that have not been completed, ordered by date (oldest first) will be displayed.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
